### PR TITLE
Add RabbitMQ for email sending

### DIFF
--- a/backend-v2/docker-compose.yml
+++ b/backend-v2/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  localRabbitMQ:
+    image: rabbitmq:3-management-alpine
+    environment:
+      RABBITMQ_DEFAULT_USER: user
+      RABBITMQ_DEFAULT_PASS: password
+    ports:
+      - "5672:5672"
+      - "15672:15672"

--- a/backend-v2/pom.xml
+++ b/backend-v2/pom.xml
@@ -55,10 +55,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-websocket</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.springframework.boot</groupId>-->
+<!--            <artifactId>spring-boot-starter-websocket</artifactId>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>org.flywaydb</groupId>
@@ -98,15 +98,27 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+<!--        <dependency>-->
+<!--            <groupId>org.springframework.security</groupId>-->
+<!--            <artifactId>spring-security-test</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+
         <dependency>
             <groupId>ua.yatsergray</groupId>
             <artifactId>backend</artifactId>
@@ -121,9 +133,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
+
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.mapstruct</groupId>

--- a/backend-v2/src/main/java/ua/yatsergray/backend/v2/config/RabbitMQConfig.java
+++ b/backend-v2/src/main/java/ua/yatsergray/backend/v2/config/RabbitMQConfig.java
@@ -1,0 +1,59 @@
+package ua.yatsergray.backend.v2.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import ua.yatsergray.backend.v2.property.RabbitMQPropertyProvider;
+
+@Configuration
+public class RabbitMQConfig {
+    private final RabbitMQPropertyProvider rabbitMQPropertyProvider;
+
+    @Autowired
+    public RabbitMQConfig(RabbitMQPropertyProvider rabbitMQPropertyProvider) {
+        this.rabbitMQPropertyProvider = rabbitMQPropertyProvider;
+    }
+
+    @Bean
+    public MessageConverter converter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public AmqpAdmin amqpAdmin(ConnectionFactory connectionFactory) {
+        return new RabbitAdmin(connectionFactory);
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+
+        rabbitTemplate.setMessageConverter(converter());
+
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public DirectExchange exchange() {
+        return new DirectExchange(rabbitMQPropertyProvider.getExchangeName(), true, false);
+    }
+
+    @Bean
+    public Queue emailInvitationQueue() {
+        return new Queue(rabbitMQPropertyProvider.getEmailInvitationQueueName());
+    }
+
+    @Bean
+    public Binding emailInvitationBinding() {
+        return BindingBuilder
+                .bind(emailInvitationQueue())
+                .to(exchange())
+                .with(rabbitMQPropertyProvider.getEmailInvitationRoutingKeyName());
+    }
+}

--- a/backend-v2/src/main/java/ua/yatsergray/backend/v2/property/RabbitMQPropertyProvider.java
+++ b/backend-v2/src/main/java/ua/yatsergray/backend/v2/property/RabbitMQPropertyProvider.java
@@ -1,0 +1,19 @@
+package ua.yatsergray.backend.v2.property;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class RabbitMQPropertyProvider {
+
+    @Value("${rabbitmq.exchange.name}")
+    private String exchangeName;
+
+    @Value("${rabbitmq.email.invitation.queue.name}")
+    private String emailInvitationQueueName;
+
+    @Value("${rabbitmq.email.invitation.routing.key.name}")
+    private String emailInvitationRoutingKeyName;
+}

--- a/backend-v2/src/main/java/ua/yatsergray/backend/v2/service/RabbitMQConsumerService.java
+++ b/backend-v2/src/main/java/ua/yatsergray/backend/v2/service/RabbitMQConsumerService.java
@@ -1,0 +1,6 @@
+package ua.yatsergray.backend.v2.service;
+
+public interface RabbitMQConsumerService<T> {
+
+    void receiveMessage(T message);
+}

--- a/backend-v2/src/main/java/ua/yatsergray/backend/v2/service/RabbitMQProducerService.java
+++ b/backend-v2/src/main/java/ua/yatsergray/backend/v2/service/RabbitMQProducerService.java
@@ -1,0 +1,6 @@
+package ua.yatsergray.backend.v2.service;
+
+public interface RabbitMQProducerService<T> {
+
+    void sendMessage(String routingKeyName, T message);
+}

--- a/backend-v2/src/main/java/ua/yatsergray/backend/v2/service/impl/InvitationRabbitMQConsumerServiceImpl.java
+++ b/backend-v2/src/main/java/ua/yatsergray/backend/v2/service/impl/InvitationRabbitMQConsumerServiceImpl.java
@@ -1,0 +1,26 @@
+package ua.yatsergray.backend.v2.service.impl;
+
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ua.yatsergray.backend.v2.domain.dto.InvitationDTO;
+import ua.yatsergray.backend.v2.service.EmailService;
+import ua.yatsergray.backend.v2.service.RabbitMQConsumerService;
+
+@Service
+@EnableRabbit
+public class InvitationRabbitMQConsumerServiceImpl implements RabbitMQConsumerService<InvitationDTO> {
+    private final EmailService emailService;
+
+    @Autowired
+    public InvitationRabbitMQConsumerServiceImpl(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @RabbitListener(queues = {"${rabbitmq.email.invitation.queue.name}"})
+    @Override
+    public void receiveMessage(InvitationDTO message) {
+        emailService.sendInvitationEmail(message.getEmail(), message.getToken());
+    }
+}

--- a/backend-v2/src/main/java/ua/yatsergray/backend/v2/service/impl/RabbitMQProducerServiceImpl.java
+++ b/backend-v2/src/main/java/ua/yatsergray/backend/v2/service/impl/RabbitMQProducerServiceImpl.java
@@ -1,0 +1,24 @@
+package ua.yatsergray.backend.v2.service.impl;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ua.yatsergray.backend.v2.property.RabbitMQPropertyProvider;
+import ua.yatsergray.backend.v2.service.RabbitMQProducerService;
+
+@Service
+public class RabbitMQProducerServiceImpl<T> implements RabbitMQProducerService<T> {
+    private final RabbitTemplate rabbitTemplate;
+    private final RabbitMQPropertyProvider rabbitMQPropertyProvider;
+
+    @Autowired
+    public RabbitMQProducerServiceImpl(RabbitTemplate rabbitTemplate, RabbitMQPropertyProvider rabbitMQPropertyProvider) {
+        this.rabbitTemplate = rabbitTemplate;
+        this.rabbitMQPropertyProvider = rabbitMQPropertyProvider;
+    }
+
+    @Override
+    public void sendMessage(String routingKeyName, T message) {
+        rabbitTemplate.convertAndSend(rabbitMQPropertyProvider.getExchangeName(), routingKeyName, message);
+    }
+}

--- a/backend-v2/src/main/resources/application.properties
+++ b/backend-v2/src/main/resources/application.properties
@@ -21,3 +21,12 @@ spring.mail.password=ykse frnk jlii spum
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.ssl.trust=smtp.gmail.com
+
+spring.rabbitmq.virtual-host=cpp
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=user
+spring.rabbitmq.password=password
+
+rabbitmq.exchange.name=exchange
+rabbitmq.email.invitation.queue.name=email-invitation-queue
+rabbitmq.email.invitation.routing.key.name=email-invitation-routing-key


### PR DESCRIPTION
Add functionality to send email invitations through RabbitMQ:
- RabbitMQConfig for RabbitMQ configuration
- RabbitMQPropertyProvider to manage RabbitMQ properties
- RabbitMQProducerService and its implementation RabbitMQProducerServiceImpl for producing messages
- RabbitMQConsumerService for consuming messages
